### PR TITLE
Drops array fetch, and corresponding hooks and providers

### DIFF
--- a/.changeset/rare-bottles-admire.md
+++ b/.changeset/rare-bottles-admire.md
@@ -1,0 +1,5 @@
+---
+'@public-assembly/zora-drops-utils': minor
+---
+
+Drops array fetch, and corresponding hooks and providers

--- a/examples/reactjs-dapp/src/components/testing/DropsArray.tsx
+++ b/examples/reactjs-dapp/src/components/testing/DropsArray.tsx
@@ -2,7 +2,7 @@ import { useSWRDropsArray } from "@public-assembly/zora-drops-utils/src/hooks"
 import { RawDisplayer } from "../RawDisplayer"
 
 export function DropsArray({contracts = []}: {contracts: string[]} ) {
-  const { data } = useSWRDropsArray({ contractAddresses: contracts })
+  const { data } = useSWRDropsArray({ contractAddresses: contracts, refreshInterval: 0 })
   
   return (
     <div><RawDisplayer data={data} /></div>

--- a/examples/reactjs-dapp/src/components/testing/DropsArray.tsx
+++ b/examples/reactjs-dapp/src/components/testing/DropsArray.tsx
@@ -1,0 +1,10 @@
+import { useSWRDropsArray } from "@public-assembly/zora-drops-utils/src/hooks"
+import { RawDisplayer } from "../RawDisplayer"
+
+export function DropsArray({contracts = []}: {contracts: string[]} ) {
+  const { data } = useSWRDropsArray({ contractAddresses: contracts })
+  
+  return (
+    <div><RawDisplayer data={data} /></div>
+  )
+}

--- a/examples/reactjs-dapp/src/components/testing/ProviderImage.tsx
+++ b/examples/reactjs-dapp/src/components/testing/ProviderImage.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { useDropsContextProvider, addIPFSGateway } from "@public-assembly/zora-drops-utils";
+import { useDropContextProvider, addIPFSGateway } from "@public-assembly/zora-drops-utils";
 
 export function ProviderImage() {
-  const { data } = useDropsContextProvider()
+  const { data } = useDropContextProvider()
   
   const src = React.useMemo(() =>
     data?.editionMetadata?.imageURI ? addIPFSGateway(data?.editionMetadata?.imageURI) : '',

--- a/examples/reactjs-dapp/src/components/testing/Test.tsx
+++ b/examples/reactjs-dapp/src/components/testing/Test.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
-import { returnDropEndpoint, DropsContextProvider } from '@public-assembly/zora-drops-utils'
+import { returnDropEndpoint, DropContextProvider, DropsContextProvider } from '@public-assembly/zora-drops-utils'
 import { RawDisplayer } from '../../../../reactjs-dapp/src/components/RawDisplayer'
 import { TestProviderConsumer } from './TestProviderConsumer'
 import { TestHooks } from './TestingHooks'
+import { DropsArray } from './DropsArray'
+import { TestArrayProviderConsumer } from './TestArrayProviderConsumer'
 
 const goreliEndpoint = returnDropEndpoint('5')
 const mainnetEndpoint = returnDropEndpoint('1')
@@ -11,7 +13,6 @@ const TEST_CONTRACTS = [
   '0xb7a791c3b5a0aa833e638250f982ebd29194f02c',
   '0x674fb9ed86b847db9aee0a19e9055d5d2c0e6cc4',
   '0x2f0146ca3c62a33177959565ae9df2f86cf01551',
-  '0x2f0146ca3c62a33177959565ae9df2f86cf015',
 ]
 
 export function TestComponent() {
@@ -29,6 +30,18 @@ export function TestComponent() {
         goerli: goreliEndpoint
       }} />
       <br />
+      <h1 className="text-xl">Array of Drops:</h1>
+      <br />
+      <DropsArray contracts={TEST_CONTRACTS} />
+      <br />
+      <hr className="border border-b-0 border-dashed"/>
+      <br />
+      <DropsContextProvider contractAddresses={TEST_CONTRACTS} refreshInterval={0}>
+        <TestArrayProviderConsumer />
+      </DropsContextProvider>
+      <br />
+      <hr className="border border-b-0 border-dashed"/>
+      <br />
       <h1 className="text-xl pb-2">Select A Contract:</h1>
       <select
         className="border border-solid border-1 p-2 border-black rounded-md"
@@ -42,9 +55,9 @@ export function TestComponent() {
       <br />
       <hr className="border border-b-0 border-dashed"/>
       <br />
-      <DropsContextProvider contractAddress={address}>
+      <DropContextProvider contractAddress={address}>
         <TestProviderConsumer />
-      </DropsContextProvider>
+      </DropContextProvider>
       <br />
       <hr className="border border-b-0 border-dashed"/>
       <br />

--- a/examples/reactjs-dapp/src/components/testing/TestArrayProviderConsumer.tsx
+++ b/examples/reactjs-dapp/src/components/testing/TestArrayProviderConsumer.tsx
@@ -1,0 +1,32 @@
+import { useDropsContextProvider } from "@public-assembly/zora-drops-utils";
+import { addIPFSGateway } from "@public-assembly/zora-drops-utils";
+
+export function ConsumerImage({src}: {src: string}) {
+  return (
+    <div style={{width: 300, height: 300}} className="relative">
+      <img src={addIPFSGateway(src)} className="object-cover inset-0 absolute" />
+    </div>
+  )
+}
+
+export function TestArrayProviderConsumer() {
+  const { data, isLoading } = useDropsContextProvider()
+  return (
+    <div className="flex flex-col">
+      <h1 className="text-xl">Using Array Provider:</h1>
+      <p>Image is separate component with no props passed in.</p>
+      <br />
+      {!isLoading
+        ? <div className="flex flex-row gap-6">
+          {/**
+           * @ts-ignore
+          */}
+          {data && data.map((edition: any) =>
+            <ConsumerImage key={edition?.name} src={edition?.editionMetadata?.imageURI} />
+          )}
+          </div>
+        : <p>...loading</p>
+      }
+    </div>
+  )
+}

--- a/examples/reactjs-dapp/src/components/testing/TestProviderConsumer.tsx
+++ b/examples/reactjs-dapp/src/components/testing/TestProviderConsumer.tsx
@@ -1,9 +1,9 @@
 import { RawDisplayer } from "./../RawDisplayer";
-import { useDropsContextProvider } from "@public-assembly/zora-drops-utils";
+import { useDropContextProvider } from "@public-assembly/zora-drops-utils";
 import { ProviderImage } from "./ProviderImage";
 
 export function TestProviderConsumer() {
-  const { data, error, isLoading, isValidAddress } = useDropsContextProvider()
+  const { data, error, isLoading } = useDropContextProvider()
   return (
     <div className="flex flex-col">
       <h1 className="text-xl">Using Provider:</h1>
@@ -12,7 +12,7 @@ export function TestProviderConsumer() {
       {!isLoading
         ? <div className="flex flex-col gap-6">
             <ProviderImage />  
-            <RawDisplayer data={{ data, error, isValidAddress }} />
+            <RawDisplayer data={{ data, error }} />
           </div>
         : <p>...loading</p>
       }

--- a/examples/reactjs-dapp/src/components/testing/TestingHooks.tsx
+++ b/examples/reactjs-dapp/src/components/testing/TestingHooks.tsx
@@ -1,13 +1,13 @@
-import { useDropsRequest, useSWRDropsRequest } from '@public-assembly/zora-drops-utils'
+import { useDrop, useSWRDrop } from '@public-assembly/zora-drops-utils'
 import { RawDisplayer } from './../RawDisplayer'
 
 export function TestHooks({contractAddress}: {contractAddress: string}) {
-  const { data, error, isLoading, isValidAddress } = useDropsRequest({
+  const { data, error, isLoading, isValidAddress } = useDrop({
     contractAddress: contractAddress,
     networkId: '1'
   })
 
-  const { data: swrData, error: swrError, isLoading: swrLoading, isValidAddress: swrValid } = useSWRDropsRequest({
+  const { data: swrData, error: swrError, isLoading: swrLoading, isValidAddress: swrValid } = useSWRDrop({
     contractAddress: contractAddress,
     networkId: '1'
   })

--- a/packages/zora-drops-utils/package.json
+++ b/packages/zora-drops-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@public-assembly/zora-drops-utils",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Example package with some web3 peer dependencies",
   "main": "dist/public-assembly-zora-drops-utils.cjs.js",
   "module": "dist/public-assembly-zora-drops-utils.esm.js",

--- a/packages/zora-drops-utils/src/context/DropContextProvider.tsx
+++ b/packages/zora-drops-utils/src/context/DropContextProvider.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { DropsRequestProps } from '../typings'
+import { useSWRDrop } from '../hooks'
+
+export type DropContextProps = {
+  children?: React.ReactNode
+}
+
+export type DropContextReturnTypes = {
+  contractAddress?: string
+  data?: any /* DAIN TODO - spec data return typings */
+  error?: any
+  isLoading?: boolean
+  isValidAddress?: boolean
+}
+
+const DropContext = React.createContext<DropContextReturnTypes>({
+  contractAddress: undefined,
+  data: null,
+  error: undefined,
+  isLoading: undefined,
+  isValidAddress: undefined,
+})
+
+export function useDropContextProvider() {
+  return React.useContext(DropContext)
+}
+
+export function DropContextProvider({
+  children,
+  contractAddress,
+  networkId = '1',
+  refreshInterval = 2000,
+}: {
+  refreshInterval?: number
+} & DropContextProps &
+  DropsRequestProps) {
+  const { data, error, isLoading, isValidAddress } = useSWRDrop({
+    contractAddress: contractAddress,
+    networkId: networkId,
+    refreshInterval: refreshInterval,
+  })
+
+  return (
+    <DropContext.Provider
+      value={{
+        contractAddress,
+        data,
+        error,
+        isLoading,
+        isValidAddress,
+      }}>
+      {children}
+    </DropContext.Provider>
+  )
+}

--- a/packages/zora-drops-utils/src/context/DropsContextProvider.tsx
+++ b/packages/zora-drops-utils/src/context/DropsContextProvider.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import { DropsRequestProps } from '../typings'
-import { useSWRDropsRequest } from '../hooks'
+import { DropsArrayRequestProps } from '../typings/requestTypes'
+import { useSWRDropsArray } from '../hooks'
 
 export type DropsContextProps = {
   children?: React.ReactNode
 }
 
 export type DropsContextReturnTypes = {
-  contractAddress?: string
+  contractAddresses?: string[]
   data?: any /* DAIN TODO - spec data return typings */
   error?: any
   isLoading?: boolean
@@ -15,7 +15,7 @@ export type DropsContextReturnTypes = {
 }
 
 const DropsContext = React.createContext<DropsContextReturnTypes>({
-  contractAddress: undefined,
+  contractAddresses: undefined,
   data: null,
   error: undefined,
   isLoading: undefined,
@@ -28,22 +28,26 @@ export function useDropsContextProvider() {
 
 export function DropsContextProvider({
   children,
-  contractAddress,
+  contractAddresses,
   networkId = '1',
-}: DropsContextProps & DropsRequestProps) {
-  const { data, error, isLoading, isValidAddress } = useSWRDropsRequest({
-    contractAddress: contractAddress,
+  refreshInterval = 2000,
+}: {
+  refreshInterval?: number
+} & DropsContextProps &
+  DropsArrayRequestProps) {
+  const { data, error, isLoading } = useSWRDropsArray({
+    contractAddresses: contractAddresses,
     networkId: networkId,
+    refreshInterval: refreshInterval,
   })
 
   return (
     <DropsContext.Provider
       value={{
-        contractAddress,
+        contractAddresses,
         data,
         error,
         isLoading,
-        isValidAddress,
       }}>
       {children}
     </DropsContext.Provider>

--- a/packages/zora-drops-utils/src/context/index.ts
+++ b/packages/zora-drops-utils/src/context/index.ts
@@ -1,1 +1,2 @@
+export * from './DropContextProvider'
 export * from './DropsContextProvider'

--- a/packages/zora-drops-utils/src/data/dropsArrayFetcher.ts
+++ b/packages/zora-drops-utils/src/data/dropsArrayFetcher.ts
@@ -1,0 +1,26 @@
+import { dropsFetcher } from './dropsFetcher'
+import { EDITION_QUERY } from './dropsQuery'
+import { DropsArrayRequestProps } from '../typings/requestTypes'
+
+export async function dropsArrayFetcher({
+  contractAddresses,
+  networkId = '1',
+}: DropsArrayRequestProps) {
+  try {
+    const editions = await Promise.all(
+      contractAddresses.map(async (contractAddress) => {
+        const metadata = await dropsFetcher(networkId, contractAddress, EDITION_QUERY)
+          .then((res) => {
+            return res
+          })
+          .catch((error) => {
+            console.error(error)
+          })
+        return metadata
+      })
+    )
+    return editions
+  } catch (err) {
+    return err
+  }
+}

--- a/packages/zora-drops-utils/src/data/index.ts
+++ b/packages/zora-drops-utils/src/data/index.ts
@@ -1,2 +1,3 @@
 export * from './dropsQuery'
 export * from './dropsFetcher'
+export * from './dropsArrayFetcher'

--- a/packages/zora-drops-utils/src/hooks/index.ts
+++ b/packages/zora-drops-utils/src/hooks/index.ts
@@ -1,2 +1,4 @@
-export * from './useDropsRequest'
-export * from './useSWRDropsRequest'
+export * from './useDrop'
+export * from './useSWRDrop'
+export * from './useDropsArray'
+export * from './useSWRDropsArray'

--- a/packages/zora-drops-utils/src/hooks/useDrop.ts
+++ b/packages/zora-drops-utils/src/hooks/useDrop.ts
@@ -3,7 +3,7 @@ import { EDITION_QUERY, dropsFetcher } from '../data'
 import { DropsRequestProps } from '../typings'
 import { useValidAddress } from './useValidAddress'
 
-export function useDropsRequest({ contractAddress, networkId = '1' }: DropsRequestProps) {
+export function useDrop({ contractAddress, networkId = '1' }: DropsRequestProps) {
   const [data, setData] = React.useState<any>(undefined)
   const [error, setError] = React.useState<any>(undefined)
   const [isLoading, setIsLoading] = React.useState(true)

--- a/packages/zora-drops-utils/src/hooks/useDropsArray.ts
+++ b/packages/zora-drops-utils/src/hooks/useDropsArray.ts
@@ -1,0 +1,40 @@
+import React from 'react'
+import { dropsArrayFetcher } from '../data'
+import { DropsArrayRequestProps } from '../typings/requestTypes'
+
+export function useDropsArray({
+  contractAddresses,
+  networkId = '1',
+}: DropsArrayRequestProps) {
+  const [data, setData] = React.useState<any>(undefined)
+  const [error, setError] = React.useState<any>(undefined)
+  const [isLoading, setIsLoading] = React.useState(true)
+
+  React.useEffect(() => {
+    setData(undefined)
+    setIsLoading(true)
+
+    async function getDropsArray() {
+      await dropsArrayFetcher({
+        contractAddresses: contractAddresses,
+        networkId: networkId,
+      })
+        .then((res) => {
+          setData(res)
+          setIsLoading(false)
+        })
+        .catch((error) => {
+          setError(error)
+          setIsLoading(false)
+          console.error(error)
+        })
+    }
+    getDropsArray()
+  }, [contractAddresses])
+
+  return {
+    data: data,
+    error: error,
+    isLoading,
+  }
+}

--- a/packages/zora-drops-utils/src/hooks/useSWRDrop.ts
+++ b/packages/zora-drops-utils/src/hooks/useSWRDrop.ts
@@ -3,10 +3,13 @@ import { EDITION_QUERY, dropsFetcher } from '../data'
 import { DropsRequestProps } from '../typings'
 import { useValidAddress } from './useValidAddress'
 
-export function useSWRDropsRequest({
+export function useSWRDrop({
   contractAddress,
   networkId = '1',
-}: DropsRequestProps) {
+  refreshInterval = 2000,
+}: {
+  refreshInterval?: number
+} & DropsRequestProps) {
   const isValidAddress = useValidAddress(contractAddress)
 
   const { data, error, isValidating } = useSWR(
@@ -14,6 +17,7 @@ export function useSWRDropsRequest({
     dropsFetcher,
     {
       isPaused: () => !isValidAddress,
+      refreshInterval: refreshInterval,
       errorRetryCount: 1,
     }
   )

--- a/packages/zora-drops-utils/src/hooks/useSWRDropsArray.ts
+++ b/packages/zora-drops-utils/src/hooks/useSWRDropsArray.ts
@@ -1,0 +1,28 @@
+import useSWR from 'swr'
+import { dropsArrayFetcher } from '../data'
+import { DropsArrayRequestProps } from '../typings/requestTypes'
+
+export function useSWRDropsArray({
+  contractAddresses,
+  networkId = '1',
+  refreshInterval = 2000,
+}: {
+  refreshInterval?: number
+} & DropsArrayRequestProps) {
+  /* Todo: add invalid address in list check? */
+  const { data, error, isValidating } = useSWR(
+    [{ contractAddresses, networkId }],
+    dropsArrayFetcher,
+    {
+      errorRetryCount: 1,
+      refreshInterval: refreshInterval,
+    }
+  )
+
+  return {
+    data,
+    error,
+    isLoading: !error && !data,
+    isValidating,
+  }
+}

--- a/packages/zora-drops-utils/src/index.ts
+++ b/packages/zora-drops-utils/src/index.ts
@@ -1,6 +1,11 @@
 export { EDITIONS_STYLE_CONTRACT_METADATA, EDITION_QUERY, dropsFetcher } from './data'
 export { DROPS_SUBGRAPH_URLS, returnDropEndpoint } from './constants'
-export { useDropsRequest, useSWRDropsRequest } from './hooks'
-export { DropsContextProvider, useDropsContextProvider } from './context'
+export { useDrop, useSWRDrop } from './hooks'
+export {
+  DropContextProvider,
+  useDropContextProvider,
+  DropsContextProvider,
+  useDropsContextProvider,
+} from './context'
 export { addIPFSGateway } from './lib/addIPFSGateway'
 export type { DropsRequestProps } from './typings'

--- a/packages/zora-drops-utils/src/index.ts
+++ b/packages/zora-drops-utils/src/index.ts
@@ -1,11 +1,21 @@
-export { EDITIONS_STYLE_CONTRACT_METADATA, EDITION_QUERY, dropsFetcher } from './data'
+export {
+  EDITIONS_STYLE_CONTRACT_METADATA,
+  EDITION_QUERY,
+  dropsFetcher,
+  dropsArrayFetcher,
+} from './data'
+
 export { DROPS_SUBGRAPH_URLS, returnDropEndpoint } from './constants'
-export { useDrop, useSWRDrop } from './hooks'
+
+export { useDrop, useSWRDrop, useDropsArray, useSWRDropsArray } from './hooks'
+
 export {
   DropContextProvider,
   useDropContextProvider,
   DropsContextProvider,
   useDropsContextProvider,
 } from './context'
+
 export { addIPFSGateway } from './lib/addIPFSGateway'
-export type { DropsRequestProps } from './typings'
+
+export type { DropsRequestProps, DropsArrayRequestProps } from './typings/requestTypes'

--- a/packages/zora-drops-utils/src/typings/requestTypes.ts
+++ b/packages/zora-drops-utils/src/typings/requestTypes.ts
@@ -4,3 +4,8 @@ export type DropsRequestProps = {
   contractAddress: string
   networkId?: ChainIds
 }
+
+export type DropsArrayRequestProps = {
+  contractAddresses: string[]
+  networkId?: ChainIds
+}


### PR DESCRIPTION
This PR incorporates utilities to work against an array of editions style contracts... takes an array addresses and returns an array of data.

This functionality does not seem to exist in the subgraph currently.

```
const TEST_CONTRACTS = [
  '0xb7a791c3b5a0aa833e638250f982ebd29194f02c',
  '0x674fb9ed86b847db9aee0a19e9055d5d2c0e6cc4',
  '0x2f0146ca3c62a33177959565ae9df2f86cf01551',
]
```
Returns:

<img width="1138" alt="Screen Shot 2022-09-28 at 2 17 18 PM" src="https://user-images.githubusercontent.com/7268786/192890502-aa8cd853-c559-4c53-b9c0-0d9af6d26262.png">

## Video
[https://www.loom.com/share/d4f98554375045cca98b5fb0a3ea8b7a](https://www.loom.com/share/d4f98554375045cca98b5fb0a3ea8b7a)